### PR TITLE
Fix random note from search

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,6 +2,7 @@
   "id": "smart-random-note",
   "name": "Smart Random Note",
   "version": "0.1.1",
+  "minAppVersion": "0.9.18",
   "description": "A smart random note plugin",
   "author": "Eric Hall",
   "authorUrl": "https://erichall.io",

--- a/src/main.ts
+++ b/src/main.ts
@@ -68,7 +68,7 @@ export default class SmartRandomNotePlugin extends Plugin {
             return;
         }
 
-        const searchResults = searchView.dom.resultDoms.map((x) => x.file.basename);
+        const searchResults = searchView.dom.getFiles().map((x) => x.basename);
 
         if (!searchResults.length) {
             new SmartRandomNoteNotice('No search results available', 5000);

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,12 +2,8 @@ import { TFile, View } from 'obsidian';
 
 export type TagFilesMap = { [tag: string]: string[] };
 
-export interface ResultDOM {
-    file: TFile;
-}
-
 export interface SearchDOM {
-    resultDoms: ResultDOM[];
+    getFiles(): TFile[];
 }
 
 export interface SearchView extends View {


### PR DESCRIPTION
The API for the search plugin was changed in Obsidian 0.9.18 which broke the open random note from search command. This fixes that.